### PR TITLE
Fix unpkg URL

### DIFF
--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -84,7 +84,7 @@ module.exports = [
             filename: 'index.js',
             path: path.resolve(__dirname, './dist/'),
             libraryTarget: 'amd',
-            publicPath: 'https://unpkg.com/qgrid@' + version + '/dist/'
+            publicPath: 'https://unpkg.com/qgrid2@' + version + '/dist/'
         },
         devtool: 'source-map',
         module: {


### PR DESCRIPTION
Follow on to d6958567fdb5ac06e7cb774c23ea9c3f7767db3f

Version in package.json is currently 1.1.3

Visiting https://unpkg.com/browse/qgrid@1.1.3/dist/ shows:

    Cannot find package qgrid@1.1.3

Visiting https://unpkg.com/browse/qgrid2@1.1.3/dist/ shows the directory
contents as expected.

Also how this URL used to work can be seen by visiting
https://unpkg.com/browse/qgrid@1.1.1/dist/ which shows the directory
contents as expected.
