### PR TITLE
Remove reference to test PyPI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -83,8 +83,6 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with: { name: artifact }
-      - name: Publish package distributions to test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          print-hash: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with: { print-hash: true }
 # vim: set filetype=yaml.action :


### PR DESCRIPTION
Also test whether a merge to main without bumping the version number result in a
deployment, an error or something else.
