### PR TITLE
Run checks at 6am each day

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,6 +2,7 @@ on: # yamllint disable-line rule:truthy
   workflow_dispatch:
   push: { branches: [main] }
   pull_request: { branches: [main] }
+  schedule: [{ cron: 0 6 * * * }]
 
 jobs:
   build:


### PR DESCRIPTION
So that incompatible releases of dependencies show as failing runs.
