### PR TITLE
Add a step to setup the current Node LTS

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,6 +18,10 @@ jobs:
         uses: actions/setup-python@v5
         with: { python-version: "3.x" }
         id: setup
+      - name: Setup Node JS current release
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - run: >-
           pipx run "--python=${{ steps.setup.outputs.python-path }}"
           reproducibly --version


### PR DESCRIPTION
So that logs like the following do not appear:

    npm warn EBADENGINE Unsupported engine {
    npm warn EBADENGINE   package: 'jackspeak@4.0.1',
    npm warn EBADENGINE   required: { node: '20 || >=22' },
    npm warn EBADENGINE   current: { node: 'v18.20.4', npm: '10.7.0' }
    npm warn EBADENGINE }
    npm warn EBADENGINE Unsupported engine {
    npm warn EBADENGINE   package: 'path-scurry@2.0.0',
    npm warn EBADENGINE   required: { node: '20 || >=22' },
    npm warn EBADENGINE   current: { node: 'v18.20.4', npm: '10.7.0' }
    npm warn EBADENGINE }
    npm warn EBADENGINE Unsupported engine {
    npm warn EBADENGINE   package: 'lru-cache@11.0.0',
    npm warn EBADENGINE   required: { node: '20 || >=22' },
    npm warn EBADENGINE   current: { node: 'v18.20.4', npm: '10.7.0' }
    npm warn EBADENGINE }
